### PR TITLE
Added new parameter to configure the view domain

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ venv
 .DS_Store
 .vscode
 db/
+.idea
+dist/

--- a/datasette_reconcile/reconcile.py
+++ b/datasette_reconcile/reconcile.py
@@ -29,10 +29,10 @@ async def reconcile_queries(queries, config, db, table):
             # characters in and sqlite3 version < 3.30.0
             # see: https://www.sqlite.org/src/info/00e9a8f2730eb723
             from_clause = """
-            {table} 
+            {table}
             inner join (
                     SELECT "rowid", "rank"
-                    FROM {fts_table} 
+                    FROM {fts_table}
                     WHERE {fts_table} MATCH :search_query
             ) as "a" on {table}."rowid" = a."rowid"
             """.format(

--- a/datasette_reconcile/reconcile.py
+++ b/datasette_reconcile/reconcile.py
@@ -85,22 +85,19 @@ def service_manifest(config, database, table, datasette, request):
     # @todo: if type_field is set then get a list of types to use in the "defaultTypes" item below.
     viewDomain = config.get("viewDomain", DEFAULT_VIEW_DOMAIN)
     if viewDomain == "":
-        viewDomain = datasette.absolute_url(request, get_view_url(datasette, database, table))
+        viewDomain = datasette.absolute_url(
+            request, get_view_url(datasette, database, table)
+        )
     else:
         viewDomain += "{{id}}"
     return {
         "versions": ["0.1", "0.2"],
         "name": config.get(
             "service_name",
-            "{database} {table} reconciliation".format(
-                database=database,
-                table=table,
-            ),
+            "{database} {table} reconciliation".format(database=database, table=table,),
         ),
         "identifierSpace": config.get("identifierSpace", DEFAULT_IDENTIFER_SPACE),
         "schemaSpace": config.get("schemaSpace", DEFAULT_SCHEMA_SPACE),
         "defaultTypes": config.get("type_default", [DEFAULT_TYPE]),
-        "view": {
-            "url": viewDomain
-        },
+        "view": {"url": viewDomain},
     }

--- a/datasette_reconcile/reconcile.py
+++ b/datasette_reconcile/reconcile.py
@@ -6,6 +6,7 @@ from datasette_reconcile.settings import (
     DEFAULT_LIMIT,
     DEFAULT_SCHEMA_SPACE,
     DEFAULT_TYPE,
+    DEFAULT_VIEW_DOMAIN,
 )
 from datasette_reconcile.utils import get_select_fields, get_view_url
 
@@ -82,6 +83,11 @@ def get_query_result(row, config, query):
 
 def service_manifest(config, database, table, datasette, request):
     # @todo: if type_field is set then get a list of types to use in the "defaultTypes" item below.
+    viewDomain = config.get("viewDomain", DEFAULT_VIEW_DOMAIN)
+    if viewDomain == "":
+        viewDomain = datasette.absolute_url(request, get_view_url(datasette, database, table))
+    else:
+        viewDomain += "{{id}}"
     return {
         "versions": ["0.1", "0.2"],
         "name": config.get(
@@ -95,8 +101,6 @@ def service_manifest(config, database, table, datasette, request):
         "schemaSpace": config.get("schemaSpace", DEFAULT_SCHEMA_SPACE),
         "defaultTypes": config.get("type_default", [DEFAULT_TYPE]),
         "view": {
-            "url": datasette.absolute_url(
-                request, get_view_url(datasette, database, table)
-            )
+            "url": viewDomain
         },
     }

--- a/datasette_reconcile/settings.py
+++ b/datasette_reconcile/settings.py
@@ -5,3 +5,4 @@ DEFAULT_TYPE = {
 }
 DEFAULT_IDENTIFER_SPACE = "http://rdf.freebase.com/ns/type.object.id"
 DEFAULT_SCHEMA_SPACE = "http://rdf.freebase.com/ns/type.object.id"
+DEFAULT_VIEW_DOMAIN = ""

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import os
 
 from setuptools import setup
 
-VERSION = "0.2.1"
+VERSION = "0.2.2"
 
 
 """


### PR DESCRIPTION
Added new parameter to configure the view domain. Useful when the link to the candidates displayed in OpenRefine should be different from the Datasette table. Implemented in response to https://github.com/drkane/datasette-reconcile/issues/20#issue-905714304. 